### PR TITLE
fix: use process.cwd() for determining project root

### DIFF
--- a/packages/vite-ui5-integration-plugin/src/plugin/BasePlugin.ts
+++ b/packages/vite-ui5-integration-plugin/src/plugin/BasePlugin.ts
@@ -135,7 +135,7 @@ export class BasePlugin {
   }
 
   protected async getAdditionalUi5Files(): Promise<Array<EmittedAsset & { id: string }>> {
-    const projectDir = path.resolve(this.viteConfig.root!, "..");
+    const projectDir = process.cwd();
     const ui5Dir = path.join(projectDir, "ui5");
 
     const manifestJson = path.resolve(ui5Dir, "./manifest.json");


### PR DESCRIPTION
path.resolve(this.viteConfig.root!, "..") doesn't work with storybook as the root is the base dir then and not "./src"