### PR TITLE
fix: runtime types for pure ESM

### DIFF
--- a/packages/vite-ui5-integration-plugin/package.json
+++ b/packages/vite-ui5-integration-plugin/package.json
@@ -9,9 +9,14 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "types": "./dist/vite-ui5-integration-plugin.d.ts",
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    ".": {
+      "types": "./dist/vite-ui5-integration-plugin.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./runtime": {
+      "types": "./runtime.d.ts"
+    }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
`moduleResolution: node16/bundler` in tsconfig requires a correct `exports` config to find runtime types